### PR TITLE
fix css for the rails asset pipeline

### DIFF
--- a/vendor/assets/stylesheets/footable-rails/footable.css.erb
+++ b/vendor/assets/stylesheets/footable-rails/footable.css.erb
@@ -15,12 +15,12 @@
 }
 
 .footable.breakpoint > tbody > tr > td.expand {
-  background: url('assets/images/plus.png') no-repeat 5px center;
+  background: url('<%= asset_data_uri "footable-rails/plus.png" %>') no-repeat 5px center;
   padding-left: 40px;
 }
 
 .footable.breakpoint > tbody > tr.footable-detail-show > td.expand {
-  background: url('assets/images/minus.png') no-repeat 5px center;
+  background: url('<%= asset_data_uri "footable-rails/minus.png" %>') no-repeat 5px center;
 }
 
 .footable.breakpoint > tbody > tr.footable-row-detail {

--- a/vendor/assets/stylesheets/footable-rails/index.css
+++ b/vendor/assets/stylesheets/footable-rails/index.css
@@ -1,2 +1,4 @@
-*= require ./footable
-*= require_tree ./plugins/
+/*
+ *= require ./footable
+ *= require_tree ./plugins/
+ */

--- a/vendor/assets/stylesheets/footable-rails/plugins/sortable/footable.sortable.css.erb
+++ b/vendor/assets/stylesheets/footable-rails/plugins/sortable/footable.sortable.css.erb
@@ -3,7 +3,7 @@
   height: 16px;
   display: block;
   float:right;
-  background: url('assets/images/sorting_sprite.png') no-repeat top left;
+  background: url('<%= asset_data_uri "footable-rails/sorting_sprite.png" %>') no-repeat top left;
 }
 
 .footable > thead > tr > th.footable-sortable:hover {


### PR DESCRIPTION
This patch fixes a syntax error and image references for footable css.
